### PR TITLE
Corrected README example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ pip install itcsmsgwclient
 ## Example usage ##
 
 ```python
-import itcsmsgwclient
+from itcsmsgwclient import itcsmsgwclient
 
 // Initialize the client
 client = itcsmsgwclient.Client(baseAddress, serviceId, username, password)


### PR DESCRIPTION
The import in the usage example was not importing the itcsmsgwclient module.

Alternatively, to make the code behave as the usage example:
This line should be added to the `__init__.py`
``` Python
from itcsmsgwclient import *
```